### PR TITLE
Exclude LICENSE/.DS_Store/.gitignore from release archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+LICENSE export-ignore
+.DS_Store export-ignore
+.gitignore export-ignore


### PR DESCRIPTION
Adds .gitattributes with export-ignore rules so GitHub release source archives omit non-skill files.

Closes #5.