### PR TITLE
Add SendGrid inbound parse skill

### DIFF
--- a/sendgrid-inbound/SKILL.md
+++ b/sendgrid-inbound/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: sendgrid-inbound
+description: Use when receiving inbound emails with SendGrid (Inbound Parse Webhook). Covers DNS/MX setup, webhook handling, payload parsing, attachments, and security.
+---
+
+# Receive Emails with SendGrid (Inbound Parse)
+
+## Overview
+
+SendGrid’s **Inbound Parse Webhook** receives emails for a specific hostname/subdomain, parses the message, and POSTs it to your webhook as `multipart/form-data`.
+
+**Key differences vs Resend:**
+- SendGrid **posts the full parsed email** (text/html/headers/attachments) directly to your webhook.
+- There is **no official signature verification** for Inbound Parse (unlike SendGrid Event Webhook). You must secure the endpoint yourself.
+
+## Quick Start
+
+1. **Create MX record** pointing to `mx.sendgrid.net` for a dedicated hostname (recommended: subdomain).
+2. **Configure Inbound Parse** in SendGrid Console with a receiving domain + destination URL.
+3. **Handle the webhook**: parse `multipart/form-data`, read `text`, `html`, `headers`, and attachments.
+4. **Secure the endpoint** (basic auth, allowlists, size limits).
+
+## DNS / MX Setup
+
+Create an MX record for a dedicated hostname:
+
+| Setting | Value |
+|---------|-------|
+| **Type** | MX |
+| **Host** | `parse` (or another subdomain) |
+| **Priority** | 10 |
+| **Value** | `mx.sendgrid.net` |
+
+**Recommendation:** Use a subdomain to avoid disrupting existing email providers (e.g., `parse.example.com`).
+
+## Inbound Parse Configuration
+
+In SendGrid Console:
+
+- **Settings → Inbound Parse**
+- Add **Receiving Domain** and **Destination URL**
+- Example receiving address: `anything@parse.example.com`
+
+## Webhook Payload (Multipart/Form-Data)
+
+SendGrid posts data like:
+
+- `from`, `to`, `cc`, `subject`
+- `text`, `html`
+- `headers` (raw email headers)
+- `envelope` (JSON with SMTP envelope data)
+- `attachments` (count)
+- `attachmentX` (file content; filename in part)
+
+**Example fields** (varies by config):
+```
+from: "Alice <alice@example.com>"
+to: "support@parse.example.com"
+subject: "Help"
+text: "Plain text body"
+html: "<p>HTML body</p>"
+headers: "...raw headers..."
+envelope: {"to":["support@parse.example.com"],"from":"alice@example.com"}
+attachments: 2
+attachment1: <file>
+attachment2: <file>
+```
+
+## Security Best Practices
+
+Because Inbound Parse has **no signature verification**, treat inbound data as untrusted:
+
+- **Require basic auth** on the webhook URL.
+- **Allowlist sender domains** if appropriate.
+- **Limit request size** (e.g., 10–25 MB) to avoid abuse.
+- **Validate content-type** (`multipart/form-data`).
+- **Do not execute or render HTML** without sanitization.
+- **Protect against prompt injection** if forwarding to AI systems.
+
+## Examples
+
+See:
+- [references/webhook-examples.md](references/webhook-examples.md)
+- [references/best-practices.md](references/best-practices.md)

--- a/sendgrid-inbound/references/best-practices.md
+++ b/sendgrid-inbound/references/best-practices.md
@@ -1,0 +1,21 @@
+# Inbound Parse Best Practices (SendGrid)
+
+## Security
+
+- **No signature verification**: protect the endpoint with basic auth and allowlists.
+- **Limit size**: reject requests above a sane size (10–25 MB).
+- **Validate content-type**: require `multipart/form-data`.
+- **Sanitize** HTML before rendering.
+- **Prompt injection**: never feed raw inbound content to LLMs without filtering.
+
+## DNS / Routing
+
+- Use a **subdomain** for inbound parse to avoid disrupting existing MX records.
+- Keep MX priority low (10).
+- Use a dedicated receiving address such as `support@parse.example.com`.
+
+## Attachments
+
+- Scan attachments before storage/processing.
+- Avoid executing attachments; treat all files as untrusted.
+- Store files in object storage with antivirus scanning when possible.

--- a/sendgrid-inbound/references/webhook-examples.md
+++ b/sendgrid-inbound/references/webhook-examples.md
@@ -1,0 +1,64 @@
+# Inbound Parse Webhook Examples (SendGrid)
+
+## Node.js (Express)
+
+```ts
+import express from 'express';
+import multer from 'multer';
+
+const app = express();
+const upload = multer({ limits: { fileSize: 25 * 1024 * 1024 } });
+
+app.post('/inbound', upload.any(), (req, res) => {
+  const { from, to, subject, text, html, headers, envelope } = req.body;
+  const attachments = req.files || [];
+
+  console.log({ from, to, subject });
+  console.log('text:', text?.slice(0, 200));
+  console.log('html:', html?.slice(0, 200));
+
+  // attachments
+  for (const file of attachments) {
+    console.log(file.originalname, file.mimetype, file.size);
+  }
+
+  res.status(200).send('OK');
+});
+```
+
+## Python (Flask)
+
+```py
+from flask import Flask, request
+
+app = Flask(__name__)
+
+@app.post('/inbound')
+def inbound():
+    form = request.form
+    files = request.files
+
+    from_addr = form.get('from')
+    to_addr = form.get('to')
+    subject = form.get('subject')
+    text = form.get('text')
+    html = form.get('html')
+
+    # attachments
+    for key, f in files.items():
+        print(key, f.filename, f.content_type)
+
+    return 'OK', 200
+```
+
+## cURL (test webhook)
+
+```bash
+curl -X POST https://your-domain.com/inbound \
+  -F from='alice@example.com' \
+  -F to='support@parse.example.com' \
+  -F subject='Hello' \
+  -F text='Plain text body' \
+  -F html='<p>HTML body</p>' \
+  -F attachment1=@./hello.txt
+```


### PR DESCRIPTION
Adds SendGrid inbound/receiving skill content (Inbound Parse Webhook), mirroring resend-skills inbound structure but tailored to SendGrid.

Included:
- Inbound Parse overview, DNS/MX setup, and webhook payload notes
- Security guidance (no signature verification, basic auth, allowlists)
- Webhook examples (Node/Express, Python/Flask, cURL)
- Best practices for attachments and routing

Closes #7.
