### PR TITLE
Exclude RELEASE_NOTES_BEST_PRACTICE.md from exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 LICENSE export-ignore
 .DS_Store export-ignore
 .gitignore export-ignore
+RELEASE_NOTES_BEST_PRACTICE.md export-ignore


### PR DESCRIPTION
Updates .gitattributes to exclude RELEASE_NOTES_BEST_PRACTICE.md from GitHub release source archives.

Closes #9.
