### PR TITLE
Fix ClawHub security flag: Add requirements metadata

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,18 @@
 ---
 name: sendgrid
 description: SendGrid email platform integration for sending and receiving emails. Routes to sub-skills for outbound transactional emails (send-email) and receiving via Inbound Parse Webhook (sendgrid-inbound). Use when user mentions SendGrid, transactional email, email API, inbound email parsing, or email webhooks. Triggers on SendGrid, send email, receive email, email webhook, Inbound Parse, transactional email.
+requirements:
+  env:
+    - SENDGRID_API_KEY
+  env_optional:
+    - SENDGRID_FROM
+  binaries:
+    - curl
+    - jq
+    - node
+  binaries_optional:
+    - dig
+    - nslookup
 ---
 
 # SendGrid


### PR DESCRIPTION
## Problem

ClawHub security scanner flagged sendgrid-skills as "Suspicious (Medium Confidence)" because the registry metadata declared no required environment variables or binaries, while the actual code clearly needs them.

**ClawHub scan:** https://clawhub.ai/vince-winkintel/sendgrid-skills

## Changes

Added `requirements` section to root `SKILL.md` YAML frontmatter:

**Required:**
- `SENDGRID_API_KEY` (env var)
- `curl`, `jq`, `node` (binaries)

**Optional:**
- `SENDGRID_FROM` (env var)
- `dig`, `nslookup` (binaries for MX record checks)

## Impact

✅ Resolves metadata mismatch  
✅ Users will know requirements up front  
✅ ClawHub security scan should pass after republish  
✅ No functional code changes (metadata only)

## Testing

- [x] Verified YAML frontmatter syntax
- [x] Confirmed requirements match actual script needs
- [x] No breaking changes to skill functionality

Fixes #17